### PR TITLE
Downloads

### DIFF
--- a/deft/download.py
+++ b/deft/download.py
@@ -46,7 +46,8 @@ def download_models(update=False):
 def get_downloaded_models():
     """Returns set of all models currently in models folder"""
     return [model for model in os.listdir(MODELS_PATH)
-            if os.path.isdir(os.path.join(MODELS_PATH, model))]
+            if os.path.isdir(os.path.join(MODELS_PATH, model))
+            and model != '__pycache__']
 
 
 def _get_s3_models():

--- a/deft/download/__init__.py
+++ b/deft/download/__init__.py
@@ -1,0 +1,1 @@
+from .download import download_models, get_downloaded_models

--- a/deft/download/__main__.py
+++ b/deft/download/__main__.py
@@ -1,0 +1,8 @@
+from deft.download import download_models
+
+"""
+Allows models to be downloaded from the command line with python -m deft.download
+
+This is useful for downloading deft models on Travis
+"""
+download_models()

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -54,11 +54,3 @@ def _get_s3_models():
     """Returns set of all models currently available on s3"""
     result = requests.get(S3_BUCKET_URL + '/s3_models.json')
     return result.json()
-
-
-if __name__ == '__main__':
-    """Download models from command line
-
-    This will allow models to be installed on Travis
-    """
-    download_models()


### PR DESCRIPTION
This PR fixes the functionality to download deft models from the command line. This can now be done with python -m deft.download. This makes it easier to download the models on Travis for the INDRA tests.