### PR TITLE
Multiple shortforms

### DIFF
--- a/deft/__init__.py
+++ b/deft/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 from .download import get_downloaded_models
 

--- a/deft/__init__.py
+++ b/deft/__init__.py
@@ -1,5 +1,5 @@
 __version__ = '0.2.0'
 
-from .download import get_downloaded_models
+from .download import get_available_models
 
-available_shortforms = get_downloaded_models()
+available_shortforms = get_available_models()

--- a/deft/disambiguate.py
+++ b/deft/disambiguate.py
@@ -124,24 +124,24 @@ class DeftDisambiguator(object):
         return result
 
 
-def load_disambiguator(shortform, models_path=MODELS_PATH):
+def load_disambiguator(model_name, models_path=MODELS_PATH):
     """Returns deft disambiguator loaded from models directory
 
     Parameters
     ----------
-    shortform : str
-        Shortform to disambiguate
+    model_name : str
+        Model_Name to disambiguate
     models_path : Optional[str]
         Path to models directory. Defaults to deft's pretrained models.
         Users have the option to specify a path to another directory to use
         custom models.
     """
-    model = load_model(os.path.join(MODELS_PATH, shortform,
-                                    shortform + '_model.gz'))
-    with open(os.path.join(MODELS_PATH, shortform,
-                           shortform + '_grounding_dict.json')) as f:
+    model = load_model(os.path.join(MODELS_PATH, model_name,
+                                    model_name + '_model.gz'))
+    with open(os.path.join(MODELS_PATH, model_name,
+                           model_name + '_grounding_dict.json')) as f:
         grounding_dict = json.load(f)
-    with open(os.path.join(MODELS_PATH, shortform,
-                           shortform + '_names.json')) as f:
+    with open(os.path.join(MODELS_PATH, model_name,
+                           model_name + '_names.json')) as f:
         names = json.load(f)
     return DeftDisambiguator(model, grounding_dict, names)

--- a/deft/disambiguate.py
+++ b/deft/disambiguate.py
@@ -5,6 +5,7 @@ import logging
 from deft.locations import MODELS_PATH
 from deft.recognize import DeftRecognizer
 from deft.modeling.classify import load_model
+from deft.download import get_available_models
 
 logger = logging.getLogger(__file__)
 
@@ -124,7 +125,7 @@ class DeftDisambiguator(object):
         return result
 
 
-def load_disambiguator(model_name, models_path=MODELS_PATH):
+def load_disambiguator(shortform, models_path=MODELS_PATH):
     """Returns deft disambiguator loaded from models directory
 
     Parameters
@@ -136,12 +137,19 @@ def load_disambiguator(model_name, models_path=MODELS_PATH):
         Users have the option to specify a path to another directory to use
         custom models.
     """
-    model = load_model(os.path.join(MODELS_PATH, model_name,
+    available = get_available_models()
+    try:
+        model_name = available[shortform]
+    except KeyError:
+        logger.error('No model available for shortform %s' % shortform)
+        return None
+
+    model = load_model(os.path.join(models_path, model_name,
                                     model_name + '_model.gz'))
-    with open(os.path.join(MODELS_PATH, model_name,
+    with open(os.path.join(models_path, model_name,
                            model_name + '_grounding_dict.json')) as f:
         grounding_dict = json.load(f)
-    with open(os.path.join(MODELS_PATH, model_name,
+    with open(os.path.join(models_path, model_name,
                            model_name + '_names.json')) as f:
         names = json.load(f)
     return DeftDisambiguator(model, grounding_dict, names)

--- a/deft/download/__init__.py
+++ b/deft/download/__init__.py
@@ -1,1 +1,1 @@
-from .download import download_models, get_downloaded_models, get_s3_models
+from .download import download_models, get_available_models, get_s3_models

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -39,7 +39,7 @@ def download_models(update=False, models=None):
         models = set(models) & s3_models
         update = True
 
-    downloaded_models = get_downloaded_models()
+    downloaded_models = get_available_models()
     for model in models:
         # if update is False do not download model
         if not update and model in downloaded_models:

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -1,8 +1,13 @@
 import os
+import json
 import wget
+import logging
 import requests
 
 from deft.locations import MODELS_PATH, S3_BUCKET_URL
+
+
+logger = logging.getLogger(__file__)
 
 
 def download_models(update=False, models=None):
@@ -70,7 +75,13 @@ def get_downloaded_models():
 def get_s3_models():
     """Returns set of all models currently available on s3"""
     result = requests.get(S3_BUCKET_URL + '/s3_models.json')
-    return result.json()
+    try:
+        output = result.json()
+        assert isinstance(output, dict)
+    except json.JSONDecodeError or AssertionError:
+        output = {}
+        logger.warning('Online deft models are currently unavailable')
+    return output
 
 
 def _remove_if_exists(path):

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -65,11 +65,11 @@ def download_models(update=False, models=None):
                           out=resource_path)
 
 
-def get_downloaded_models():
+def get_available_models(models_path=MODELS_PATH):
     """Returns set of all models currently in models folder"""
     output = {}
-    for model in os.listdir(MODELS_PATH):
-        model_path = os.path.join(MODELS_PATH, model)
+    for model in os.listdir(models_path):
+        model_path = os.path.join(models_path, model)
         if os.path.isdir(model_path) and model != '__pycache__':
             if model == 'TEST':
                 output['TEST'] = 'TEST'

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -67,9 +67,24 @@ def download_models(update=False, models=None):
 
 def get_downloaded_models():
     """Returns set of all models currently in models folder"""
-    return [model for model in os.listdir(MODELS_PATH)
-            if os.path.isdir(os.path.join(MODELS_PATH, model))
-            and model != '__pycache__']
+    output = {}
+    for model in os.listdir(MODELS_PATH):
+        model_path = os.path.join(MODELS_PATH, model)
+        if os.path.isdir(model_path) and model != '__pycache__':
+            if model == 'TEST':
+                output['TEST'] = 'TEST'
+                continue
+            grounding_file = '%s_grounding_dict.json' % model
+            with open(os.path.join(model_path, grounding_file), 'r') as f:
+                grounding_dict = json.load(f)
+            for key, value in grounding_dict.items():
+                if key in output:
+                    logger.warning('Shortform %s has multiple deft models'
+                                   'This may lead to unexpected behavior'
+                                   % key)
+                else:
+                    output[key] = model
+    return output
 
 
 def get_s3_models():

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -32,16 +32,15 @@ def download_models(update=False, models=None):
         as True regardless of how it was set. These should be considered
         as mutually exclusive parameters.
     """
-    s3_models = get_s3_models()
+    s3_models = set(get_s3_models().values())
     if models is None:
-        models = set(s3_models.values())
+        models = s3_models
     else:
-        models = set(models) & set(s3_models.values())
+        models = set(models) & s3_models
         update = True
 
     downloaded_models = get_downloaded_models()
     for model in models:
-        print(model)
         # if update is False do not download model
         if not update and model in downloaded_models:
             continue
@@ -57,13 +56,13 @@ def download_models(update=False, models=None):
             _remove_if_exists(resource_path)
             wget.download(url=os.path.join(S3_BUCKET_URL, model, resource),
                           out=resource_path)
-        # if model == 'TEST':
-        #     resource_path = os.path.join(MODELS_PATH, model,
-        #                                  'example_training_data.json')
-        #     _remove_if_exists(resource_path)
-        #     wget.download(url=os.path.join(S3_BUCKET_URL, model,
-        #                                    'example_training_data.json'),
-        #                   out=resource_path)
+        if model == 'TEST':
+            resource_path = os.path.join(MODELS_PATH, model,
+                                         'example_training_data.json')
+            _remove_if_exists(resource_path)
+            wget.download(url=os.path.join(S3_BUCKET_URL, model,
+                                           'example_training_data.json'),
+                          out=resource_path)
 
 
 def get_downloaded_models():

--- a/deft/modeling/classify.py
+++ b/deft/modeling/classify.py
@@ -172,7 +172,8 @@ class DeftClassifier(object):
         # Fit grid_search and set the estimator for the instance of the class
         grid_search = GridSearchCV(logit_pipeline, param_grid,
                                    cv=cv, n_jobs=n_jobs, scoring=scorer,
-                                   refit='f1', iid=False)
+                                   refit='f1', iid=False,
+                                   return_train_score=False)
         grid_search.fit(texts, y)
         logger.info('Best f1 score of %s found for' % grid_search.best_score_
                     + ' parameter values:\n%s' % grid_search.best_params_)

--- a/deft/modeling/classify.py
+++ b/deft/modeling/classify.py
@@ -46,8 +46,8 @@ class DeftClassifier(object):
        all positive labels weighted by the number of datapoints with each
        label.
     """
-    def __init__(self, shortform, pos_labels):
-        self.shortform = shortform
+    def __init__(self, shortforms, pos_labels):
+        self.shortforms = shortforms
         self.pos_labels = pos_labels
 
     def train(self, texts, y, C=1.0, ngram_range=(1, 2), max_features=1000):
@@ -153,8 +153,6 @@ class DeftClassifier(object):
             recall_scorer = make_scorer(recall_score,
                                         pos_label=self.pos_labels[0],
                                         average='binary')
-            f1_scorer = make_scorer(f1_score, pos_label=self.pos_labels[0],
-                                    average='binary')
 
         scorer = {'f1': f1_scorer, 'pr': precision_scorer,
                   'rc': recall_scorer}
@@ -217,7 +215,7 @@ class DeftClassifier(object):
                       'tfidf': {'vocabulary_': vocabulary_,
                                 'idf_': idf_,
                                 'ngram_range': ngram_range},
-                      'shortform': self.shortform,
+                      'shortforms': self.shortforms,
                       'pos_labels': self.pos_labels}
         json_str = json.dumps(model_info)
         json_bytes = json_str.encode('utf-8')
@@ -242,10 +240,10 @@ def load_model(filepath):
     json_str = json_bytes.decode('utf-8')
     model_info = json.loads(json_str)
 
-    shortform = model_info['shortform']
+    shortforms = model_info['shortforms']
     pos_labels = model_info['pos_labels']
 
-    longform_model = DeftClassifier(shortform=shortform,
+    longform_model = DeftClassifier(shortforms=shortforms,
                                     pos_labels=pos_labels)
     ngram_range = model_info['tfidf']['ngram_range']
     tfidf = TfidfVectorizer(ngram_range=ngram_range)

--- a/deft/modeling/corpora.py
+++ b/deft/modeling/corpora.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from deft.recognize import DeftRecognizer
 
 
@@ -47,11 +49,16 @@ class DeftCorpusBuilder(object):
             defining pattern.
         """
         corpus = []
+        counts = defaultdict(int)
         for text in texts:
             data_points = self._process_text(text)
             if data_points:
                 corpus.extend(data_points)
-        return corpus
+                labels = sorted(label for _, label in data_points)
+                key = '::'.join(labels)
+                counts[key] += 1
+
+        return corpus, dict(counts)
 
     def _process_text(self, text):
         """Returns training data and label corresponding to text if found

--- a/deft/modeling/corpora.py
+++ b/deft/modeling/corpora.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from deft.recognize import DeftRecognizer
 
 
@@ -49,16 +47,11 @@ class DeftCorpusBuilder(object):
             defining pattern.
         """
         corpus = []
-        counts = defaultdict(int)
         for text in texts:
             data_points = self._process_text(text)
             if data_points:
                 corpus.extend(data_points)
-                labels = sorted(label for _, label in data_points)
-                key = '::'.join(labels)
-                counts[key] += 1
-
-        return corpus, dict(counts)
+        return corpus
 
     def _process_text(self, text):
         """Returns training data and label corresponding to text if found

--- a/deft/modeling/corpora.py
+++ b/deft/modeling/corpora.py
@@ -28,7 +28,7 @@ class DeftCorpusBuilder(object):
         self.recognizers = [DeftRecognizer(shortform, grounding_map)
                             for shortform, grounding_map
                             in grounding_dict.items()]
-        
+
     def build_from_texts(self, texts):
         """Build corpus from a list of texts
 
@@ -41,7 +41,7 @@ class DeftCorpusBuilder(object):
         -------
         corpus : list of tuple
             Contains tuples for each text in the input list which contains
-            a defining pattern. Multiple tuples correspond to  texts with
+            a defining pattern. Multiple tuples correspond to texts with
             multiple defining patterns for longforms with different groundings.
             The first element of each tuple contains the training text with all
             defining patterns replaced with only the shortform. The second

--- a/deft/tests/test_classify.py
+++ b/deft/tests/test_classify.py
@@ -7,12 +7,12 @@ from sklearn.metrics import f1_score
 
 from deft.locations import MODELS_PATH
 from deft.modeling.classify import DeftClassifier, load_model
-from deft.download import get_downloaded_models, download_models
+from deft.download import get_available_models, download_models
 
 # Get test path so we can write a temporary file here
 TESTS_PATH = os.path.dirname(os.path.abspath(__file__))
 
-if 'TEST' not in get_downloaded_models():
+if 'TEST' not in get_available_models():
     download_models(models=['TEST'])
 
 with open(os.path.join(MODELS_PATH, 'TEST',

--- a/deft/tests/test_classify.py
+++ b/deft/tests/test_classify.py
@@ -27,7 +27,7 @@ def test_train():
     params = {'C': 1.0,
               'ngram_range': (1, 2),
               'max_features': 1000}
-    classifier = DeftClassifier('IR', ['HGNC:6091', 'MESH:D011839'])
+    classifier = DeftClassifier(['IR'], ['HGNC:6091', 'MESH:D011839'])
     texts = data['texts']
     labels = data['labels']
     classifier.train(texts, labels, **params)
@@ -41,7 +41,7 @@ def test_train():
 def test_cv_multiclass():
     params = {'C': [1.0],
               'max_features': [1000]}
-    classifier = DeftClassifier('IR', ['HGNC:6091', 'MESH:D011839'])
+    classifier = DeftClassifier(['IR'], ['HGNC:6091', 'MESH:D011839'])
     texts = data['texts']
     labels = data['labels']
     classifier.cv(texts, labels, param_grid=params, cv=2)
@@ -55,7 +55,7 @@ def test_cv_binary():
     texts = data['texts']
     labels = [label if label == 'HGNC:6091' else 'ungrounded'
               for label in data['labels']]
-    classifier = DeftClassifier('IR', ['HGNC:6091'])
+    classifier = DeftClassifier(['IR'], ['HGNC:6091'])
     classifier.cv(texts, labels, param_grid=params, cv=2)
     assert classifier.best_score > 0.5
 

--- a/deft/tests/test_classify.py
+++ b/deft/tests/test_classify.py
@@ -66,7 +66,7 @@ def test_serialize():
     texts = data['texts']
     temp_filename = os.path.join(TESTS_PATH, uuid.uuid4().hex)
     classifier1 = load_model(os.path.join(MODELS_PATH, 'TEST',
-                                          'test_model.gz'))
+                                          'TEST_model.gz'))
     classifier1.dump_model(temp_filename)
 
     classifier2 = load_model(temp_filename)

--- a/deft/tests/test_corpora.py
+++ b/deft/tests/test_corpora.py
@@ -132,7 +132,5 @@ def test_build_from_texts():
 
 def test__build_from_texts_multiple():
     dcb = DeftCorpusBuilder({'NP': groundings1, 'NPs': groundings2})
-    corpus, counts = dcb.build_from_texts([text5, text6, text7])
-    assert counts['nano'] == 2
-    assert counts['nano::peptide'] == 1
+    corpus = dcb.build_from_texts([text5, text6, text7])
     assert set(corpus) == set(result_corpus2)

--- a/deft/tests/test_corpora.py
+++ b/deft/tests/test_corpora.py
@@ -93,6 +93,11 @@ text7 = ('Nanoparticle (NP) PET/CT imaging of natriuretic peptide (NP)'
 result7 = ('NP PET/CT imaging of NP clearance receptor in prostate cancer.')
 labels7 = set(['nano', 'peptide'])
 
+result_corpus2 = [(result[0], label) for result in [(result5, labels5),
+                                                    (result6, labels6),
+                                                    (result7, labels7)]
+                  for label in result[1]]
+
 
 def test__process_text():
     dcb = DeftCorpusBuilder({'INDRA': longforms})
@@ -129,4 +134,8 @@ def test_build_from_texts():
 
 
 def test__build_from_texts_multiple():
-    pass
+    dcb = DeftCorpusBuilder({'NP': groundings1, 'NPs': groundings2})
+    corpus, counts = dcb.build_from_texts([text5, text6, text7])
+    assert counts['nano'] == 2
+    assert counts['nano::peptide'] == 1
+    assert set(corpus) == set(result_corpus2)

--- a/deft/tests/test_corpora.py
+++ b/deft/tests/test_corpora.py
@@ -1,6 +1,7 @@
 from deft.modeling.corpora import DeftCorpusBuilder
 
 
+# content for single shortform corpus building
 longforms = {'integrated network and dynamical reasoning assembler':
              'our indra',
              'indonesian debt restructuring agency': 'other indra'}
@@ -68,9 +69,33 @@ result_corpus = [(result[0], label) for result in [(result1, labels1),
                                                    (result3, labels3)]
                  for label in result[1]]
 
+#  content for corpus building with synomous shortforms
+groundings1 = {'nanoparticle': 'nano',
+               'natriuretic peptide': 'peptide'}
+
+groundings2 = {'nanoparticles': 'nano',
+               'natriuretic peptides': 'peptide'}
+
+text5 = ('The application of nanoparticles (NPs) for industrial processes'
+         ' and consumer products is rising at an exponential rate.')
+result5 = ('The application of NPs for industrial processes and consumer'
+           ' products is rising at an exponential rate.')
+labels5 = set(['nano'])
+
+text6 = ('Understanding the mechanism of nanoparticle (NP) induced toxicity'
+         ' is important for nanotoxicological and nanomedicinal studies.')
+result6 = ('Understanding the mechanism of NP induced toxicity is important'
+           ' for nanotoxicological and nanomedicinal studies.')
+labels6 = set(['nano'])
+
+text7 = ('Nanoparticle (NP) PET/CT imaging of natriuretic peptide (NP)'
+         ' clearance receptor in prostate cancer.')
+result7 = ('NP PET/CT imaging of NP clearance receptor in prostate cancer.')
+labels7 = set(['nano', 'peptide'])
+
 
 def test__process_text():
-    dcb = DeftCorpusBuilder('INDRA', longforms)
+    dcb = DeftCorpusBuilder({'INDRA': longforms})
 
     for text, result, labels in [(text1, result1, labels1),
                                  (text2, result2, labels2),
@@ -83,7 +108,22 @@ def test__process_text():
     assert dcb._process_text(text4) is None
 
 
+def test__process_text_multiple():
+    dcb = DeftCorpusBuilder({'NP': groundings1, 'NPs': groundings2})
+    for text, result, labels in [(text5, result5, labels5),
+                                 (text6, result6, labels6),
+                                 (text7, result7, labels7)]:
+        datapoints = dcb._process_text(text)
+        assert len(datapoints) == len(labels)
+        assert all([datapoint[0] == result for datapoint in datapoints])
+        assert all([datapoint[1] in labels for datapoint in datapoints])
+
+
 def test_build_from_texts():
-    dcb = DeftCorpusBuilder('INDRA', longforms)
+    dcb = DeftCorpusBuilder({'INDRA': longforms})
     corpus = dcb.build_from_texts([text1, text2, text3, text4])
     assert set(corpus) == set(result_corpus)
+
+
+def test__build_from_texts_multiple():
+    pass

--- a/deft/tests/test_corpora.py
+++ b/deft/tests/test_corpora.py
@@ -64,10 +64,10 @@ labels3 = set(['other indra'])
 
 text4 = 'We cannot determine what INDRA means from this sentence.'
 
-result_corpus1 = [(result[0], label) for result in [(result1, labels1),
-                                                    (result2, labels2),
-                                                    (result3, labels3)]
-                  for label in result[1]]
+result_corpus = [(result[0], label) for result in [(result1, labels1),
+                                                   (result2, labels2),
+                                                   (result3, labels3)]
+                 for label in result[1]]
 
 #  content for corpus building with synomous shortforms
 groundings1 = {'nanoparticle': 'nano',
@@ -126,11 +126,8 @@ def test__process_text_multiple():
 
 def test_build_from_texts():
     dcb = DeftCorpusBuilder({'INDRA': longforms})
-    corpus, counts = dcb.build_from_texts([text1, text2, text3, text4])
-    assert counts['our indra'] == 1
-    assert counts['other indra::our indra'] == 1
-    assert counts['other indra'] == 1
-    assert set(corpus) == set(result_corpus1)
+    corpus = dcb.build_from_texts([text1, text2, text3, text4])
+    assert set(corpus) == set(result_corpus)
 
 
 def test__build_from_texts_multiple():

--- a/deft/tests/test_corpora.py
+++ b/deft/tests/test_corpora.py
@@ -64,10 +64,10 @@ labels3 = set(['other indra'])
 
 text4 = 'We cannot determine what INDRA means from this sentence.'
 
-result_corpus = [(result[0], label) for result in [(result1, labels1),
-                                                   (result2, labels2),
-                                                   (result3, labels3)]
-                 for label in result[1]]
+result_corpus1 = [(result[0], label) for result in [(result1, labels1),
+                                                    (result2, labels2),
+                                                    (result3, labels3)]
+                  for label in result[1]]
 
 #  content for corpus building with synomous shortforms
 groundings1 = {'nanoparticle': 'nano',
@@ -121,8 +121,11 @@ def test__process_text_multiple():
 
 def test_build_from_texts():
     dcb = DeftCorpusBuilder({'INDRA': longforms})
-    corpus = dcb.build_from_texts([text1, text2, text3, text4])
-    assert set(corpus) == set(result_corpus)
+    corpus, counts = dcb.build_from_texts([text1, text2, text3, text4])
+    assert counts['our indra'] == 1
+    assert counts['other indra::our indra'] == 1
+    assert counts['other indra'] == 1
+    assert set(corpus) == set(result_corpus1)
 
 
 def test__build_from_texts_multiple():

--- a/deft/tests/test_disambiguate.py
+++ b/deft/tests/test_disambiguate.py
@@ -22,21 +22,21 @@ example3 = ('IR is a transmembrane receptor that is activated by insulin,'
 
 def test_load_disambiguator():
     dd_test = load_disambiguator('TEST')
-    assert dd_test.shortform == 'IR'
+    assert dd_test.shortforms == ['IR']
     assert hasattr(dd_test, 'classifier')
-    assert hasattr(dd_test, 'recognizer')
+    assert hasattr(dd_test, 'recognizers')
 
 
 def test_disambiguate():
     test_model = load_model(os.path.join(MODELS_PATH, 'TEST',
-                                         'test_model.gz'))
+                                         'TEST_model.gz'))
     with open(os.path.join(MODELS_PATH, 'TEST',
-                           'test_grounding_map.json')) as f:
-        grounding_map = json.load(f)
-    with open(os.path.join(MODELS_PATH, 'TEST', 'test_names.json')) as f:
+                           'TEST_grounding_dict.json')) as f:
+        grounding_dict = json.load(f)
+    with open(os.path.join(MODELS_PATH, 'TEST', 'TEST_names.json')) as f:
         names = json.load(f)
 
-    dd = DeftDisambiguator(test_model, grounding_map, names)
+    dd = DeftDisambiguator(test_model, grounding_dict, names)
     # case where there is a unique defining pattern
     disamb1 = dd.disambiguate([example1])[0]
     assert disamb1[0] == 'HGNC:6091'

--- a/deft/tests/test_download.py
+++ b/deft/tests/test_download.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from deft.locations import MODELS_PATH
-from deft.download import download_models, get_downloaded_models, \
+from deft.download import download_models, get_available_models, \
     get_s3_models
 
 
@@ -18,8 +18,8 @@ def test_download_models():
     test_model_folder = os.path.join(MODELS_PATH, 'TEST')
     if os.path.isdir(test_model_folder):
         shutil.rmtree(test_model_folder)
-    assert 'TEST' not in get_downloaded_models()
+    assert 'TEST' not in get_available_models()
 
     # Download models
     download_models(models=['TEST'])
-    assert 'TEST' in get_downloaded_models()
+    assert 'TEST' in get_available_models()


### PR DESCRIPTION
This PR allows deft to build disambiguators with synonymous shortforms. This is useful for cases such as NP, NPs where the latter is the plural of the former. This should bring significant improvement in disambiguation performance for cases like this, since it increases the chance of finding a defining pattern in a text and also allows models to have more training data.