### PR TITLE
Test model bug fix

### DIFF
--- a/deft/__init__.py
+++ b/deft/__init__.py
@@ -2,4 +2,6 @@ __version__ = '0.2.0'
 
 from .download import get_available_models
 
-available_shortforms = get_available_models()
+available_shortforms = {shortform: model
+                        for shortform, model in get_available_models().items()
+                        if model != '__TEST'}

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -56,7 +56,7 @@ def download_models(update=False, models=None):
             _remove_if_exists(resource_path)
             wget.download(url=os.path.join(S3_BUCKET_URL, model, resource),
                           out=resource_path)
-        if model == 'TEST':
+        if model == '__TEST':
             resource_path = os.path.join(MODELS_PATH, model,
                                          'example_training_data.json')
             _remove_if_exists(resource_path)
@@ -71,8 +71,8 @@ def get_available_models(models_path=MODELS_PATH):
     for model in os.listdir(models_path):
         model_path = os.path.join(models_path, model)
         if os.path.isdir(model_path) and model != '__pycache__':
-            if model == 'TEST':
-                output['TEST'] = 'TEST'
+            if model == '__TEST':
+                output['__TEST'] = '__TEST'
                 continue
             grounding_file = '%s_grounding_dict.json' % model
             with open(os.path.join(model_path, grounding_file), 'r') as f:

--- a/deft/tests/test_classify.py
+++ b/deft/tests/test_classify.py
@@ -13,9 +13,9 @@ from deft.download import get_available_models, download_models
 TESTS_PATH = os.path.dirname(os.path.abspath(__file__))
 
 if 'TEST' not in get_available_models():
-    download_models(models=['TEST'])
+    download_models(models=['__TEST'])
 
-with open(os.path.join(MODELS_PATH, 'TEST',
+with open(os.path.join(MODELS_PATH, '__TEST',
                        'example_training_data.json'), 'r') as f:
     data = json.load(f)
 
@@ -65,8 +65,8 @@ def test_serialize():
     """
     texts = data['texts']
     temp_filename = os.path.join(TESTS_PATH, uuid.uuid4().hex)
-    classifier1 = load_model(os.path.join(MODELS_PATH, 'TEST',
-                                          'TEST_model.gz'))
+    classifier1 = load_model(os.path.join(MODELS_PATH, '__TEST',
+                                          '__TEST_model.gz'))
     classifier1.dump_model(temp_filename)
 
     classifier2 = load_model(temp_filename)

--- a/deft/tests/test_disambiguate.py
+++ b/deft/tests/test_disambiguate.py
@@ -21,19 +21,19 @@ example3 = ('IR is a transmembrane receptor that is activated by insulin,'
 
 
 def test_load_disambiguator():
-    dd_test = load_disambiguator('TEST')
+    dd_test = load_disambiguator('__TEST')
     assert dd_test.shortforms == ['IR']
     assert hasattr(dd_test, 'classifier')
     assert hasattr(dd_test, 'recognizers')
 
 
 def test_disambiguate():
-    test_model = load_model(os.path.join(MODELS_PATH, 'TEST',
-                                         'TEST_model.gz'))
-    with open(os.path.join(MODELS_PATH, 'TEST',
-                           'TEST_grounding_dict.json')) as f:
+    test_model = load_model(os.path.join(MODELS_PATH, '__TEST',
+                                         '__TEST_model.gz'))
+    with open(os.path.join(MODELS_PATH, '__TEST',
+                           '__TEST_grounding_dict.json')) as f:
         grounding_dict = json.load(f)
-    with open(os.path.join(MODELS_PATH, 'TEST', 'TEST_names.json')) as f:
+    with open(os.path.join(MODELS_PATH, '__TEST', '__TEST_names.json')) as f:
         names = json.load(f)
 
     dd = DeftDisambiguator(test_model, grounding_dict, names)

--- a/deft/tests/test_download.py
+++ b/deft/tests/test_download.py
@@ -9,17 +9,17 @@ from deft.download import download_models, get_available_models, \
 def test_get_s3_models():
     """Test function to check which models are available on S3"""
     models = get_s3_models()
-    assert 'TEST' in models
+    assert '__TEST' in models
 
 
 def test_download_models():
     """Test downloading of models from S3"""
     # Remove test models folder if it exists
-    test_model_folder = os.path.join(MODELS_PATH, 'TEST')
+    test_model_folder = os.path.join(MODELS_PATH, '__TEST')
     if os.path.isdir(test_model_folder):
         shutil.rmtree(test_model_folder)
-    assert 'TEST' not in get_available_models()
+    assert '__TEST' not in get_available_models()
 
     # Download models
-    download_models(models=['TEST'])
-    assert 'TEST' in get_available_models()
+    download_models(models=['__TEST'])
+    assert '__TEST' in get_available_models()


### PR DESCRIPTION
This PR fixes a bug that caused TEST to be among the available shortforms due to this being the name of the test model. The test model is now ignored when checking available shortforms. It has been renamed to __TEST so it's possible to build a disambiguation model for the shortform TEST if desired.