### PR TITLE
Increase maximum number of characters included in label

### DIFF
--- a/deft/modeling/classify.py
+++ b/deft/modeling/classify.py
@@ -251,8 +251,8 @@ def load_model(filepath):
 
     tfidf.vocabulary_ = model_info['tfidf']['vocabulary_']
     tfidf.idf_ = model_info['tfidf']['idf_']
-
-    logit.classes_ = np.array(model_info['logit']['classes_'])
+    logit.classes_ = np.array(model_info['logit']['classes_'],
+                              dtype='<U32')
     logit.intercept_ = np.array(model_info['logit']['intercept_'])
     logit.coef_ = np.array(model_info['logit']['coef_'])
 


### PR DESCRIPTION
Since numpy arrays have to have fixed size entries, calling np.array on a list of strings makes an array where each entrie has maximum number of characters equal to that of the longest string in the input list. Previously this had no effect, but since we are now allowing for the hot fixing of groundings, we would like to be able to modify class labels after training. By explicitly setting the width of the labels to larger than any possible grounding label, we need not worry that the new label is longer than any previously existing label. As things currently stand, labels are truncated if they are longer than a currently existing label.