### PR TITLE
Expose pos labels

### DIFF
--- a/deft/disambiguate.py
+++ b/deft/disambiguate.py
@@ -45,6 +45,7 @@ class DeftDisambiguator(object):
         self.names = names
         self.labels = set(value for grounding_map in grounding_dict.values()
                           for value in grounding_map.values())
+        self.pos_labels = classifier.pos_labels
 
     def disambiguate(self, texts):
         """Return disambiguations for a list of texts

--- a/deft/modeling/classify.py
+++ b/deft/modeling/classify.py
@@ -1,18 +1,15 @@
 import gzip
 import json
 import logging
-import warnings
 import numpy as np
 
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection import GridSearchCV
-from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import f1_score, precision_score, recall_score,\
     make_scorer
 
-warnings.filterwarnings("ignore", category=ConvergenceWarning)
 
 logger = logging.getLogger(__file__)
 


### PR DESCRIPTION
This PR exposes the positive labels as an attribute of a DeftDisambiguator. This will allow INDRA to be aware of which labels to keep when using DEFT for grounding mapping.