### PR TITLE
Models folder

### DIFF
--- a/deft/download/__main__.py
+++ b/deft/download/__main__.py
@@ -1,4 +1,7 @@
+import os
 import argparse
+
+from deft.locations import MODELS_PATH
 from deft.download import download_models
 
 """
@@ -13,5 +16,8 @@ parser = argparse.ArgumentParser(description='Download models from S3')
 parser.add_argument('--update', action='store_true',
                     help='Update existing models if they have changed on S3')
 args = parser.parse_args()
+
+if not os.path.exists(MODELS_PATH):
+    os.makedirs(MODELS_PATH)
 
 download_models(update=args.update)

--- a/deft/download/download.py
+++ b/deft/download/download.py
@@ -67,6 +67,8 @@ def download_models(update=False, models=None):
 
 def get_available_models(models_path=MODELS_PATH):
     """Returns set of all models currently in models folder"""
+    if not os.path.exists(models_path):
+        return {}
     output = {}
     for model in os.listdir(models_path):
         model_path = os.path.join(models_path, model)

--- a/deft/locations.py
+++ b/deft/locations.py
@@ -1,5 +1,6 @@
 import os
 
 DEFT_PATH = os.path.dirname(os.path.abspath(__file__))
-MODELS_PATH = DEFT_PATH + '/models'
+MODELS_PATH = os.path.join(os.path.expanduser('~'),
+                           '.deft_models')
 S3_BUCKET_URL = 'http://deft-models.s3.amazonaws.com'

--- a/deft/modeling/classify.py
+++ b/deft/modeling/classify.py
@@ -1,15 +1,18 @@
 import gzip
 import json
 import logging
+import warnings
 import numpy as np
 
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection import GridSearchCV
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import f1_score, precision_score, recall_score,\
     make_scorer
 
+warnings.filterwarnings("ignore", category=ConvergenceWarning)
 
 logger = logging.getLogger(__file__)
 

--- a/deft/models/.gitignore
+++ b/deft/models/.gitignore
@@ -1,4 +1,0 @@
-*
-*/
-!.gitignore
-!__init__.py


### PR DESCRIPTION
This PR sets the models folder to live in the users home directory instead of within the deft package itself. This is to handle cases where the user does not have write permission for the directory where deft is installed.